### PR TITLE
Use WKWebView instead of UIWebView on iOS

### DIFF
--- a/src/components/Payment/index.ios.js
+++ b/src/components/Payment/index.ios.js
@@ -32,7 +32,7 @@ class Payment extends React.Component {
         card_quota: PropTypes.arrayOf(PropTypes.number)
       }),
       merchant_uid: PropTypes.string.isRequired,
-      amoung: PropTypes.oneOfType([
+      amount: PropTypes.oneOfType([
         PropTypes.string.isRequired,
         PropTypes.number.isRequired,
       ]),
@@ -191,6 +191,7 @@ class Payment extends React.Component {
           originWhitelist={['*']} // https://github.com/facebook/react-native/issues/19986
           injectedJavaScript={this.getInjectedJavascript()} // https://github.com/facebook/react-native/issues/10865
           onNavigationStateChange={this.onNavigationStateChange}
+          useWebKit
         />
       );
     }


### PR DESCRIPTION
iOS 결제 Component 의 WebView 가 default 값인 UIWebView 로 설정되어 있어
에러가 발생하는 점 확인하여 `useWebKit` 옵션을 `true` 로 설정하여 WKWebView 을
사용하도록 설정했습니다.

propTypes 의 amount 단어가 amoung 로 오타가 있어 수정했습니다.