### PR TITLE
[android] fix Gradle to use root project's version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,15 +9,20 @@ buildscript {
     }
 }
 
+def DEFAULT_COMPILE_SDK_VERSION             = 26
+def DEFAULT_BUILD_TOOLS_VERSION             = "26.0.3"
+def DEFAULT_MIN_SDK_VERSION                 = 16
+def DEFAULT_TARGET_SDK_VERSION              = 22
+
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.3"
+    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : DEFAULT_MIN_SDK_VERSION
+        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"
     }
@@ -33,4 +38,3 @@ repositories {
 dependencies {
     compile 'com.facebook.react:react-native:+'
 }
-  


### PR DESCRIPTION
안녕하세요 적용중에 오류가 발생해서 다음과 같이 PR 드립니다.

메인 프로젝트의 compileSdk나 minSdk 를 상위버전으로 업데이트 하게 되면 이전 버전과 충돌하는 오류가 간혹 생기는데 root 프로젝트의 SDK 버전을 사용하면, 이 현상이 잘 해결 되어 공유 드립니다.