### PR TITLE
페이지 이동마다 javascript inject로 인해 IMP is not defined 오류가 발생하지 않도록 수정

### DIFF
--- a/src/components/Certification/index.js
+++ b/src/components/Certification/index.js
@@ -10,7 +10,12 @@ import Validation from '../../utils/Validation';
 import { WEBVIEW_SOURCE_HTML, CARRIERS } from '../../constants';
 
 export function Certification({ userCode, data, loading, callback }) {
+  let iamportTriggered = false;
+
   function onLoadEnd() {
+    if (iamportTriggered) return;
+    iamportTriggered = true;
+
     this.xdm.injectJavaScript(`
       IMP.init("${userCode}");
       IMP.certification(${JSON.stringify(data)}, function(response) {
@@ -18,8 +23,8 @@ export function Certification({ userCode, data, loading, callback }) {
       });
     `);
   }
-  
-  function onMessage(e) { // 본인인증 결과를 받아 callback을 실행한다 
+
+  function onMessage(e) { // 본인인증 결과를 받아 callback을 실행한다
     const { data } = e.nativeEvent;
     let response = data;
     while(decodeURIComponent(response) !== response) {

--- a/src/components/Payment/PaymentWebView.js
+++ b/src/components/Payment/PaymentWebView.js
@@ -25,6 +25,8 @@ export function PaymentWebView({
   open3rdPartyApp,
 }) {
   useEffect(() => {
+    let iamportTriggered = false;
+
     function handleOpenURL(event) {
       const { pg, pay_method } = data;
       if (pay_method === 'trans') {
@@ -44,13 +46,16 @@ export function PaymentWebView({
       }
     }
     Linking.addEventListener('url', handleOpenURL);
-    
+
     return function cleanup() {
       Linking.removeEventListener('url', handleOpenURL);
     }
   });
 
   function onLoadEnd() {
+    if (iamportTriggered) return;
+    iamportTriggered = true;
+
     data.m_redirect_url = IamportUrl.M_REDIRECT_URL;
     if (data.pg === 'eximbay') {
       data.popup = false;
@@ -65,7 +70,7 @@ export function PaymentWebView({
       });
     `);
   }
-  
+
   /* PG사가 callback을 지원하는 경우, 결제결과를 받아 callback을 실행한다 */
   function onMessage(e) {
     const { data } = e.nativeEvent;
@@ -108,7 +113,7 @@ export function PaymentWebView({
       />
     );
   }
-  
+
   return <ErrorOnParams message={validation.getMessage()} />;
 }
 


### PR DESCRIPTION
Payment, Certification 요청 시 최초에만 IMP.init() & IMP.request_pay() 또는 IMP.certification()을 호출하도록 플래그 설정