### PR TITLE
Set requiresMainQueueSetup to YES

### DIFF
--- a/ios/IamportReactNativeViewManager.m
+++ b/ios/IamportReactNativeViewManager.m
@@ -6,7 +6,7 @@ RCT_EXPORT_VIEW_PROPERTY(color, NSString)
 
 + (BOOL)requiresMainQueueSetup
 {
-    return NO;
+    return YES;
 }
 
 @end


### PR DESCRIPTION
I'm getting the following error in [2.0.0-rc.1](https://github.com/iamport/iamport-react-native/releases/tag/v2.0.0-rc.1):

```
WARN Module IamportReactNativeViewManager requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
```

<img src="https://user-images.githubusercontent.com/931655/155950706-f1a48163-fc73-4d62-9047-7b9194a31cd5.PNG" width="320">
