### PR TITLE
Improve url split to fix undefined error

### DIFF
--- a/src/utils/IamportUrl.ts
+++ b/src/utils/IamportUrl.ts
@@ -10,8 +10,8 @@ class IamportUrl {
 
   constructor(url: string) {
     this.url = url;
-    let splittedUrl = url.replace('://', ' ').split(' ');
-    this.scheme = splittedUrl[0];
+    this.scheme = url.split('://', 1)[0];
+    let splittedUrl = [this.scheme, url.slice(this.scheme.length + 3)];
     if (Platform.OS === 'ios') {
       this.path =
         this.scheme === 'itmss' ? `https://${splittedUrl[1]}` : this.url;


### PR DESCRIPTION
# iamport에서 intent 불가

| 사진 1 | 사진 2|
|:---:|:---:|
| ![image](https://user-images.githubusercontent.com/46197097/183621451-aacdbc84-f4c3-483b-a1aa-667c1bee2357.png) | ![image](https://user-images.githubusercontent.com/46197097/183621549-1551801d-dc35-4b13-b6fa-21a526275825.png) |

### 상황 (플로우)
NicePay 일반 카드결제 진행 중 [현대, NH 농협]과 같이 Ahnlab v3 mobile plus가 필요한 카드사를 통해 결제를 시도할 경우 발생했습니다.

### 에러 나는 부분

```jsx
if (_reactNative.Platform.OS === 'ios') {
      this.path = this.scheme === 'itmss' ? `https://${splittedUrl[1]}` : this.url;
    } else if (_reactNative.Platform.OS === 'android') {
      if (this.isAppUrl()) {
        if (this.scheme.includes('intent')) {
          let intentUrl = splittedUrl[1].split('#Intent;');
          let host = intentUrl[0];
          let args = intentUrl[1].split(';');
```

### 해결방법
url을 split할 때 기존과 같이 ' ' 공백을 기준으로 하게 되면, 그 뒤로 들어오는 값에 공백이 있는 경우 의도대로 동작하지 않습니다.
소스의 의도였던 scheme과 그 뒤의 컨텐츠로 나누기 위해 소스를 수정합니다.