### PR TITLE
Payment Response Type 지정

### DIFF
--- a/example/ios/IamportReactNativeExample.xcodeproj/project.pbxproj
+++ b/example/ios/IamportReactNativeExample.xcodeproj/project.pbxproj
@@ -795,7 +795,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -857,7 +857,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - iamport-react-native (2.0.1):
+  - iamport-react-native (2.0.2):
     - React-Core
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.180)
@@ -524,7 +524,7 @@ SPEC CHECKSUMS:
   FlipperKit: aec2d931adeee48a07bab1ea8bcc8a6bb87dfce4
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 5337263514dd6f09803962437687240c5dc39aa4
-  iamport-react-native: f6b9f0d0c7c0f4c4dc2b119c143a95a20b166a3a
+  iamport-react-native: 2effc6d89aebafca5117c214b7ed22c8d163cbb5
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCT-Folly: 0dd9e1eb86348ecab5ba76f910b56f4b5fef3c46

--- a/example/src/NavigationService.tsx
+++ b/example/src/NavigationService.tsx
@@ -27,7 +27,7 @@ export type RootStackParamList = {
   CertificationResult: any;
   Payment: PaymentParams | undefined;
   PaymentTest: undefined;
-  PaymentResult: any;
+  PaymentResult: IMPData.PaymentResponse;
 };
 
 const RootStack = createStackNavigator<RootStackParamList>();

--- a/example/src/Payment/index.tsx
+++ b/example/src/Payment/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import IMP from 'iamport-react-native';
+import IMP, { IMPData } from 'iamport-react-native';
 import type { StackScreenProps } from '@react-navigation/stack';
 import type { RootStackParamList } from '../NavigationService';
 import { getUserCode } from '../utils';
@@ -20,7 +20,9 @@ function Payment({ route, navigation }: Props) {
         tierCode={tierCode}
         loading={<Loading />}
         data={params!}
-        callback={(response) => navigation.replace('PaymentResult', response)}
+        callback={(response: IMPData.PaymentResponse) =>
+          navigation.replace('PaymentResult', response)
+        }
       />
     </SafeAreaView>
   );

--- a/src/utils/Validation.ts
+++ b/src/utils/Validation.ts
@@ -70,16 +70,16 @@ class Validation {
 namespace IMPData {
   /**
    * @details 결제수단
-   * @param card 신용카드
-   * @param trans 실시간계좌이체
-   * @param vbank 가상계좌
-   * @param phone 휴대폰소액결제
-   * @param kakaopay 이니시스, KCP, 나이스페이먼츠를 통한 카카오페이 직접 호출
-   * @param payco 이니시스, KCP를 통한 페이코 직접 호출
-   * @param lpay 이니시스를 통한 LPAY 직접 호출
-   * @param ssgpay 이니시스를 통한 SSG페이 직접 호출
-   * @param tosspay 이니시스를 통한 토스간편결제 직접 호출
-   * @param point 카카오페이, PAYCO, 이니시스, 나이스페이먼츠 내 간편결제 시 해당 간편결제 자체 포인트 100% 결제
+   * @type card 신용카드
+   * @type trans 실시간계좌이체
+   * @type vbank 가상계좌
+   * @type phone 휴대폰소액결제
+   * @type kakaopay 이니시스, KCP, 나이스페이먼츠를 통한 카카오페이 직접 호출
+   * @type payco 이니시스, KCP를 통한 페이코 직접 호출
+   * @type lpay 이니시스를 통한 LPAY 직접 호출
+   * @type ssgpay 이니시스를 통한 SSG페이 직접 호출
+   * @type tosspay 이니시스를 통한 토스간편결제 직접 호출
+   * @type point 카카오페이, PAYCO, 이니시스, 나이스페이먼츠 내 간편결제 시 해당 간편결제 자체 포인트 100% 결제
    */
   type IPayMethod =
     | 'card'
@@ -95,21 +95,21 @@ namespace IMPData {
 
   /**
    * @details 결제상태
-   * @param ready 브라우저 창 이탈, 가상계좌 발급 완료 등 미결제 상태
-   * @param paid 결제완료
-   * @param failed 신용카드 한도 초과, 체크카드 잔액 부족, 브라우저 창 종료 또는 취소 버튼 클릭 등 결제실패 상태
+   * @type ready 브라우저 창 이탈, 가상계좌 발급 완료 등 미결제 상태
+   * @type paid 결제완료
+   * @type failed 신용카드 한도 초과, 체크카드 잔액 부족, 브라우저 창 종료 또는 취소 버튼 클릭 등 결제실패 상태
    */
   type IStatus = 'ready' | 'paid' | 'failed';
 
   /**
    * @details 결제승인/시도된 PG사
-   * @param html5_inicis 웹표준방식의 KG이니시스
-   * @param inicis 일반 KG이니시스
-   * @param kakaopay 카카오페이
-   * @param uplus 토스페이먼츠(구 LG U+)
-   * @param nice 나이스정보통신
-   * @param jtnet JTNet
-   * @param danal 다날
+   * @type html5_inicis 웹표준방식의 KG이니시스
+   * @type inicis 일반 KG이니시스
+   * @type kakaopay 카카오페이
+   * @type uplus 토스페이먼츠(구 LG U+)
+   * @type nice 나이스정보통신
+   * @type jtnet JTNet
+   * @type danal 다날
    */
   type IPgProvider =
     | 'html5_inicis'

--- a/src/utils/Validation.ts
+++ b/src/utils/Validation.ts
@@ -68,6 +68,58 @@ class Validation {
 }
 
 namespace IMPData {
+  /**
+   * @details 결제수단
+   * @param card 신용카드
+   * @param trans 실시간계좌이체
+   * @param vbank 가상계좌
+   * @param phone 휴대폰소액결제
+   * @param kakaopay 이니시스, KCP, 나이스페이먼츠를 통한 카카오페이 직접 호출
+   * @param payco 이니시스, KCP를 통한 페이코 직접 호출
+   * @param lpay 이니시스를 통한 LPAY 직접 호출
+   * @param ssgpay 이니시스를 통한 SSG페이 직접 호출
+   * @param tosspay 이니시스를 통한 토스간편결제 직접 호출
+   * @param point 카카오페이, PAYCO, 이니시스, 나이스페이먼츠 내 간편결제 시 해당 간편결제 자체 포인트 100% 결제
+   */
+  type PayMethod =
+    | 'card'
+    | 'trans'
+    | 'vbank'
+    | 'phone'
+    | 'kakaopay'
+    | 'payco'
+    | 'lpay'
+    | 'ssgpay'
+    | 'tosspay'
+    | 'point';
+
+  /**
+   * @details 결제상태
+   * @param ready 브라우저 창 이탈, 가상계좌 발급 완료 등 미결제 상태
+   * @param paid 결제완료
+   * @param failed 신용카드 한도 초과, 체크카드 잔액 부족, 브라우저 창 종료 또는 취소 버튼 클릭 등 결제실패 상태
+   */
+  type Status = 'ready' | 'paid' | 'failed';
+
+  /**
+   * @details 결제승인/시도된 PG사
+   * @param html5_inicis 웹표준방식의 KG이니시스
+   * @param inicis 일반 KG이니시스
+   * @param kakaopay 카카오페이
+   * @param uplus 토스페이먼츠(구 LG U+)
+   * @param nice 나이스정보통신
+   * @param jtnet JTNet
+   * @param danal 다날
+   */
+  type PgProvider =
+    | 'html5_inicis'
+    | 'inicis'
+    | 'kakaopay'
+    | 'uplus'
+    | 'nice'
+    | 'jtnet'
+    | 'danal';
+
   interface ICertificationData {
     merchant_uid: string;
     company: string;
@@ -232,6 +284,95 @@ namespace IMPData {
     popup?: boolean;
     tax_free?: number;
     vbank_due?: string;
+  }
+
+  interface IPaymentResponse {
+    success: boolean;
+    error_code: string;
+    error_msg: string;
+    imp_uid: string | null;
+    merchant_uid: string;
+    pay_method?: PayMethod;
+    paid_amount?: number;
+    status?: Status;
+    name?: string;
+    pg_provider?: PgProvider;
+    emb_pg_provider?: string;
+    pg_tid?: string;
+    buyer_name?: string;
+    buyer_email?: string;
+    buyer_tel?: string;
+    buyer_addr?: string;
+    buyer_postcode?: string;
+    custom_data?: object;
+    paid_at?: number;
+    receipt_url?: string;
+  }
+
+  export class PaymentResponse implements IPaymentResponse {
+    constructor(
+      success: boolean,
+      error_code: string,
+      error_msg: string,
+      imp_uid: string | null,
+      merchant_uid: string,
+      pay_method?: PayMethod,
+      paid_amount?: number,
+      status?: Status,
+      name?: string,
+      pg_provider?: PgProvider,
+      emb_pg_provider?: string,
+      pg_tid?: string,
+      buyer_name?: string,
+      buyer_email?: string,
+      buyer_tel?: string,
+      buyer_addr?: string,
+      buyer_postcode?: string,
+      custom_data?: object,
+      paid_at?: number,
+      receipt_url?: string
+    ) {
+      this.success = success;
+      this.error_code = error_code;
+      this.error_msg = error_msg;
+      this.imp_uid = imp_uid;
+      this.merchant_uid = merchant_uid;
+      this.pay_method = pay_method;
+      this.paid_amount = paid_amount;
+      this.status = status;
+      this.name = name;
+      this.pg_provider = pg_provider;
+      this.emb_pg_provider = emb_pg_provider;
+      this.pg_tid = pg_tid;
+      this.buyer_name = buyer_name;
+      this.buyer_email = buyer_email;
+      this.buyer_tel = buyer_tel;
+      this.buyer_addr = buyer_addr;
+      this.buyer_postcode = buyer_postcode;
+      this.custom_data = custom_data;
+      this.paid_at = paid_at;
+      this.receipt_url = receipt_url;
+    }
+    success: boolean;
+    error_code: string;
+    error_msg: string;
+    imp_uid: string | null;
+    merchant_uid: string;
+    pay_method?: PayMethod;
+    paid_amount?: number;
+    status?: Status;
+    name?: string;
+    pg_provider?: PgProvider;
+    emb_pg_provider?: string;
+    pg_tid?: string;
+    buyer_name?: string;
+    buyer_email?: string;
+    buyer_tel?: string;
+    buyer_addr?: string;
+    buyer_postcode?: string;
+    custom_data?: object;
+    paid_at?: number;
+    receipt_url?: string;
   }
 }
 

--- a/src/utils/Validation.ts
+++ b/src/utils/Validation.ts
@@ -81,7 +81,7 @@ namespace IMPData {
    * @param tosspay 이니시스를 통한 토스간편결제 직접 호출
    * @param point 카카오페이, PAYCO, 이니시스, 나이스페이먼츠 내 간편결제 시 해당 간편결제 자체 포인트 100% 결제
    */
-  type PayMethod =
+  type IPayMethod =
     | 'card'
     | 'trans'
     | 'vbank'
@@ -99,7 +99,7 @@ namespace IMPData {
    * @param paid 결제완료
    * @param failed 신용카드 한도 초과, 체크카드 잔액 부족, 브라우저 창 종료 또는 취소 버튼 클릭 등 결제실패 상태
    */
-  type Status = 'ready' | 'paid' | 'failed';
+  type IStatus = 'ready' | 'paid' | 'failed';
 
   /**
    * @details 결제승인/시도된 PG사
@@ -111,7 +111,7 @@ namespace IMPData {
    * @param jtnet JTNet
    * @param danal 다날
    */
-  type PgProvider =
+  type IPgProvider =
     | 'html5_inicis'
     | 'inicis'
     | 'kakaopay'
@@ -119,6 +119,8 @@ namespace IMPData {
     | 'nice'
     | 'jtnet'
     | 'danal';
+
+  type ISuccess = 'true' | 'false' | true | false;
 
   interface ICertificationData {
     merchant_uid: string;
@@ -164,7 +166,7 @@ namespace IMPData {
 
   interface IPaymentData {
     pg: string;
-    pay_method: string;
+    pay_method: IPayMethod;
     currency?: string;
     notice_url?: string | string[];
     display?: {
@@ -204,7 +206,7 @@ namespace IMPData {
       escrow: boolean,
       merchant_uid: string,
       name: string,
-      pay_method: string,
+      pay_method: IPayMethod,
       pg: string,
       language?: string,
       naverPopupMode?: boolean,
@@ -279,7 +281,7 @@ namespace IMPData {
     naverUseCfm?: string;
     niceMobileV2?: boolean = true;
     notice_url?: string | string[];
-    pay_method: string;
+    pay_method: IPayMethod;
     pg: string;
     popup?: boolean;
     tax_free?: number;
@@ -287,16 +289,17 @@ namespace IMPData {
   }
 
   interface IPaymentResponse {
-    success: boolean;
+    success?: ISuccess;
+    imp_success?: ISuccess;
     error_code: string;
     error_msg: string;
     imp_uid: string | null;
     merchant_uid: string;
-    pay_method?: PayMethod;
+    pay_method?: IPayMethod;
     paid_amount?: number;
-    status?: Status;
+    status?: IStatus;
     name?: string;
-    pg_provider?: PgProvider;
+    pg_provider?: IPgProvider;
     emb_pg_provider?: string;
     pg_tid?: string;
     buyer_name?: string;
@@ -311,16 +314,17 @@ namespace IMPData {
 
   export class PaymentResponse implements IPaymentResponse {
     constructor(
-      success: boolean,
       error_code: string,
       error_msg: string,
       imp_uid: string | null,
       merchant_uid: string,
-      pay_method?: PayMethod,
+      success?: ISuccess,
+      imp_success?: ISuccess,
+      pay_method?: IPayMethod,
       paid_amount?: number,
-      status?: Status,
+      status?: IStatus,
       name?: string,
-      pg_provider?: PgProvider,
+      pg_provider?: IPgProvider,
       emb_pg_provider?: string,
       pg_tid?: string,
       buyer_name?: string,
@@ -333,6 +337,7 @@ namespace IMPData {
       receipt_url?: string
     ) {
       this.success = success;
+      this.imp_success = imp_success;
       this.error_code = error_code;
       this.error_msg = error_msg;
       this.imp_uid = imp_uid;
@@ -353,16 +358,17 @@ namespace IMPData {
       this.paid_at = paid_at;
       this.receipt_url = receipt_url;
     }
-    success: boolean;
+    success?: ISuccess;
+    imp_success?: ISuccess;
     error_code: string;
     error_msg: string;
     imp_uid: string | null;
     merchant_uid: string;
-    pay_method?: PayMethod;
+    pay_method?: IPayMethod;
     paid_amount?: number;
-    status?: Status;
+    status?: IStatus;
     name?: string;
-    pg_provider?: PgProvider;
+    pg_provider?: IPgProvider;
     emb_pg_provider?: string;
     pg_tid?: string;
     buyer_name?: string;


### PR DESCRIPTION
결제 성공 / 실패 후 callback 함수에서 반환하는 파라미터에 대한 타입이 있으면 구현함에 있어 조금 더 편할것 같아 PR 보내드립니다.

새로 추가한 interface에 대한 property 정의는 아임포트 dosc를 참고하였습니다.

[payment rsp](https://docs.iamport.kr/sdk/javascript-sdk?lang=ko#request_pay-rsp)