### PR TITLE
chore: add kbbank on ios manual setting guide md

### DIFF
--- a/manuals/SETTING.md
+++ b/manuals/SETTING.md
@@ -60,6 +60,7 @@ iOS에서 아임포트 결제연동 모듈을 사용하기 위해서는 아래 3
   <string>hanawalletmembers</string> <!-- 하나카드(하나멤버스 월렛) -->
   <string>chaipayment</string> <!-- 차이 -->
   <string>kb-auth</string> <!-- 국민 -->
+  <string>kbbank</string> <!-- 국민 스타뱅킹 -->
   <string>hyundaicardappcardid</string>  <!-- 현대카드 -->
   <string>com.wooricard.wcard</string>  <!-- 우리won페이 -->
   <string>lmslpay</string>  <!-- 롯데 L페이 -->


### PR DESCRIPTION
## 상황 (플로우)
NicePayment를 통해 KB스타뱅킹 앱 결제로 이동하는 경우 에러가 발생함

https://user-images.githubusercontent.com/46197097/232002404-d2e942a1-bded-4903-baff-19f70702d996.MP4


## 에러 메시지
``` bash
Unable to open URL: kbbank://call?cmd=move_to&id=web&url=/mquics?page=D007436&urlparam=tcode:1150984. Add kbbank to LSApplicationQueriesSchemes in your Info.plist.
```

## 해결 방법
에러 메시지의 안내에 따라 info.plist에 `kbbank` scheme 추가하는것으로 해결.
**Ios 매뉴얼 설치 가이드 문서에는 누락된 내용이기 때문에 추가.**