### PR TITLE
Payment 컴포넌트의 Linking 이벤트 구독 해제

### DIFF
--- a/src/components/Payment/index.tsx
+++ b/src/components/Payment/index.tsx
@@ -99,7 +99,10 @@ function Payment({ userCode, tierCode, data, loading, callback }: Props) {
         }
       }
     };
-    Linking.addEventListener('url', handleOpenURL);
+    const subscription = Linking.addEventListener('url', handleOpenURL);
+    return function cleanup() {
+      subscription.remove();
+    }
   }, [data, isInicisTransPaid, redirectUrl, webview]);
 
   const removeLoadingNeeded = () => {


### PR DESCRIPTION
안녕하세요.

RN `Linking` API의 `url` 이벤트 구독이 적절히 해제되지 않고 있는 것으로 보여
간단히 추가해보았습니다.

RN 0.70 브레이킹 체인지를 고려하여 `remove()`를 호출합니다.

피드백이 있으시면 편하게 주시길 바랍니다!

감사합니다.
