### PR TITLE
안드로이드 내통장결제에서 로딩 컴포넌트 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 아임포트 리액트 네이티브 모듈입니다.
 
 ## 버전 정보
-최신버전은 [v2.0.9](https://github.com/iamport/iamport-react-native/tree/v2.0.9)입니다.
+최신버전은 [v2.0.10](https://github.com/iamport/iamport-react-native/tree/v2.0.10)입니다.
 버전 히스토리는 [버전 정보](./manuals/VERSION.md)를 참고하세요.
 
 ## 지원 정보

--- a/manuals/VERSION.md
+++ b/manuals/VERSION.md
@@ -1,6 +1,9 @@
 # 버전정보
 아임포트 리액트 네이티브 모듈 버전 정보 안내입니다.
-- [v2.0.9](https://github.com/iamport/iamport-react-native/tree/main)
+- [v2.0.10](https://github.com/iamport/iamport-react-native/tree/main)
+  - 헥토파이낸셜 내통장결제에서 안드로이드 환경에서 로딩 컴포넌트가 제거되지 않는 현상을 해결했습니다.
+
+- [v2.0.9](https://github.com/iamport/iamport-react-native/tree/v2.0.9)
   - settle_acc enum을 추가했습니다.
   - 신한 슈퍼SOL 앱스킴을 추가했습니다.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iamport-react-native",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "리액트 네이티브용 아임포트 결제/본인인증 연동 라이브러리",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/components/Payment/index.tsx
+++ b/src/components/Payment/index.tsx
@@ -133,7 +133,8 @@ function Payment({ userCode, tierCode, data, loading, callback }: Props) {
       pg.startsWith('danal_tpay') ||
       pg.startsWith('smilepay') ||
       pg.startsWith('payco') ||
-      pg.startsWith('bluewalnut')
+      pg.startsWith('bluewalnut') ||
+      pg.startsWith('settle_acc')
     );
   };
 


### PR DESCRIPTION
안드로이드에서 헥토파이낸셜 내통장결제를 사용하게 되면 로딩컴포넌트가 제거되지 않아 결제를 하지 못해 이를 수정했습니다.