### PR TITLE
query-string 9.x 지원하게끔 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript": "^4.9.4"
   },
   "peerDependencies": {
-    "query-string": "8.x",
+    "query-string": "8.x || 9.x",
     "react": "*",
     "react-native": "*",
     "react-native-webview": ">=11.x"


### PR DESCRIPTION
Peer deps로 query-string 9.x 버전을 가질 수 있게끔 했습니다.

9.x 버전과 8.x 버전의 차이는 Node.js 18 이상을 강제한다는 점만 존재하기 때문에 
9버전을 쓸 수 있다면 8버전과는 호환되어, 이를 반영해주었습니다.
https://github.com/sindresorhus/query-string/releases/tag/v9.0.0

query-string 버전을 9 버전으로 올리는 방법도 존재하나, 이러면 breaking change가 되기 때문에 일단 위와 같이 처리해주었습니다.
