### PR TITLE
ci: GitHub Actions 보안 취약점 수정 (zizmor)

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.2
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - name: Setup Node.js 24.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:


### PR DESCRIPTION
## 개요

[zizmor](https://github.com/woodruffw/zizmor)로 GitHub Actions 워크플로우 보안 감사를 수행하고 자동 수정 가능한 항목을 적용했습니다.

## 수정 내용

- **ref-version-mismatch**: 액션의 SHA 핀과 버전 주석이 불일치하는 항목을 올바른 버전으로 수정 (`pnpm/action-setup` v6.0.2 → v6.0.3 주석 업데이트)